### PR TITLE
Misc fixes

### DIFF
--- a/bbot_server/config.py
+++ b/bbot_server/config.py
@@ -121,7 +121,7 @@ def get_api_key():
         except StopIteration:
             raise BBOTServerError(
                 f"No API keys found in the config. Please set `api_keys` in your config file or run `bbctl server apikey add`"
-        )
+            )
 
 
 def check_api_key(api_key: str):

--- a/bbot_server/config.py
+++ b/bbot_server/config.py
@@ -152,7 +152,7 @@ def add_api_key():
     global VALID_API_KEYS
     api_key = uuid.uuid4()
     VALID_API_KEYS.add(api_key)
-    BBOT_SERVER_CONFIG["api_keys"] = sorted(VALID_API_KEYS)
+    BBOT_SERVER_CONFIG["api_keys"] = sorted([str(key) for key in VALID_API_KEYS])
 
     # write new API key to config
     existing_config = OmegaConf.load(BBOT_SERVER_CONFIG_PATH)

--- a/bbot_server/config.py
+++ b/bbot_server/config.py
@@ -4,7 +4,7 @@ import logging
 from pathlib import Path
 from omegaconf import OmegaConf
 
-from bbot_server.errors import BBOTServerError
+from bbot_server.errors import BBOTServerError, BBOTServerValueError
 
 
 log = logging.getLogger("bbot_server.config")
@@ -96,7 +96,10 @@ def refresh_api_keys():
         if keys:
             if isinstance(keys, str):
                 keys = [keys]
-            api_keys.update(keys)
+            try:
+                api_keys.update([uuid.UUID(key) for key in keys])
+            except ValueError as e:
+                raise BBOTServerValueError(f"Invalid API key in config") from e
     VALID_API_KEYS = api_keys
 
 
@@ -108,11 +111,16 @@ def get_api_keys():
 
 
 def get_api_key():
+    # prioritize single api key if set
     try:
-        return next(iter(VALID_API_KEYS))
-    except StopIteration:
-        raise BBOTServerError(
-            f"No API keys found in the config. Please set `api_keys` in your config file or run `bbctl server apikey add`"
+        return str(uuid.UUID(BBOT_SERVER_CONFIG.get("api_key", "")))
+    except ValueError:
+        # otherwise, return the first valid API key
+        try:
+            return str(next(iter(VALID_API_KEYS)))
+        except StopIteration:
+            raise BBOTServerError(
+                f"No API keys found in the config. Please set `api_keys` in your config file or run `bbctl server apikey add`"
         )
 
 
@@ -124,14 +132,14 @@ def check_api_key(api_key: str):
     if not api_key:
         return False, "API key is required"
     try:
-        api_key = str(uuid.UUID(api_key))
+        api_key = uuid.UUID(api_key)
     except Exception:
         return False, "API key must be a valid UUID"
     # if the API key is invalid, try refreshing the config
     if api_key not in VALID_API_KEYS:
         refresh_config()
         if api_key not in VALID_API_KEYS:
-            return False, f'Invalid API key "{api_key}" not in {VALID_API_KEYS}'
+            return False, f'Invalid API key "{api_key}"'
     return True, "Valid API key"
 
 
@@ -142,14 +150,14 @@ def add_api_key():
     Note: writes the config to disk
     """
     global VALID_API_KEYS
-    api_key = str(uuid.uuid4())
+    api_key = uuid.uuid4()
     VALID_API_KEYS.add(api_key)
     BBOT_SERVER_CONFIG["api_keys"] = sorted(VALID_API_KEYS)
 
     # write new API key to config
     existing_config = OmegaConf.load(BBOT_SERVER_CONFIG_PATH)
     existing_api_keys = set(existing_config.get("api_keys", []))
-    existing_api_keys.add(api_key)
+    existing_api_keys.add(str(api_key))
     existing_config["api_keys"] = sorted(existing_api_keys)
     OmegaConf.save(existing_config, BBOT_SERVER_CONFIG_PATH)
 
@@ -163,7 +171,11 @@ def revoke_api_key(api_key: str):
     Revoke an API key from the config.
     """
     global VALID_API_KEYS
-    VALID_API_KEYS.remove(str(api_key))
+    try:
+        api_key = str(uuid.UUID(api_key))
+    except ValueError as e:
+        raise BBOTServerValueError(f"Invalid API key") from e
+    VALID_API_KEYS.remove(api_key)
     refresh_config()
 
 

--- a/bbot_server/logger.py
+++ b/bbot_server/logger.py
@@ -22,10 +22,12 @@ console_handler = logging.StreamHandler()
 console_handler.setFormatter(logging.Formatter(FORMAT, datefmt="[%X]"))
 logger.addHandler(console_handler)
 
-# Create file handler for debug logs in ~/.bbot_server/debug.log
+# Create file handler for debug logs in ~/.bbot_server/debug.log (plain text)
+# We only compress the rotated log files, not the active one, so keep the
+# base file extension as .log rather than .log.gz.
 log_dir = Path.home() / ".bbot_server"
 log_dir.mkdir(exist_ok=True)
-log_file = log_dir / "debug.log.gz"
+log_file = log_dir / "debug.log"
 
 
 class GzipRotatingFileHandler(RotatingFileHandler):
@@ -41,9 +43,11 @@ class GzipRotatingFileHandler(RotatingFileHandler):
 
     def rotation_filename(self, default_name):
         """
-        Modify the rotated filename to include .gz extension
+        Ensure the rotated filename ends with `.gz` so that the compressed
+        file is easy to identify. If the default_name already includes the
+        suffix (it should not, but guard just in case) we leave it untouched.
         """
-        return default_name + ".gz"
+        return default_name if default_name.endswith(".gz") else default_name + ".gz"
 
     def rotate(self, source, dest):
         """

--- a/bbot_server/modules/activity/activity_models.py
+++ b/bbot_server/modules/activity/activity_models.py
@@ -39,6 +39,7 @@ class Activity(BaseBBOTServerModel):
     netloc: Annotated[Optional[str], "indexed"] = None
     url: Annotated[Optional[str], "indexed"] = None
     module: Annotated[Optional[str], "indexed"] = None
+    scan: Annotated[Optional[str], "indexed"] = None
     parent_event_uuid: Annotated[Optional[str], "indexed"] = None
     parent_event_id: Annotated[Optional[str], "indexed"] = None
     parent_scan_run_id: Annotated[Optional[str], "indexed"] = None
@@ -80,6 +81,8 @@ class Activity(BaseBBOTServerModel):
             self.port = event.port
         if event.netloc and not self.netloc:
             self.netloc = event.netloc
+        if event.scan and not self.scan:
+            self.scan = event.scan
         # handle url
         event_data_json = getattr(event, "data_json", None)
         if event_data_json is not None:
@@ -98,6 +101,7 @@ class Activity(BaseBBOTServerModel):
             "port",
             "module",
             "netloc",
+            "scan",
             "parent_event_id",
             "parent_event_uuid",
             "parent_scan_run_id",

--- a/bbot_server/modules/agents/agent.py
+++ b/bbot_server/modules/agents/agent.py
@@ -121,14 +121,14 @@ class BBOTAgent:
 
         try:
             preset_obj = Preset.from_dict(preset)
-            agent_preset.merge(preset_obj)
+            preset_obj.merge(agent_preset)
         except BaseException as e:
             return {"status": "error", "message": f"Error parsing preset: {e} - {traceback.format_exc()}"}
 
         try:
             # create scanner
             scan = Scanner(
-                preset=agent_preset,
+                preset=preset_obj,
                 scan_id=scan_id,
                 dispatcher=self.dispatcher,
             )

--- a/bbot_server/modules/targets/targets_cli.py
+++ b/bbot_server/modules/targets/targets_cli.py
@@ -47,7 +47,7 @@ class TargetCTL(BaseBBCTL):
             strict_dns_scope=strict_dns_scope,
         )
         self.log.info(f"Target created successfully:")
-        self.print_json(target.model_dump(), highlight=True)
+        self.print_json(target.model_dump(), colorize=True)
 
     @subcommand(help="Delete a target")
     def delete(
@@ -125,7 +125,7 @@ class TargetCTL(BaseBBCTL):
     @subcommand(help="Get a target by its name or ID")
     def get(self, target_id: Annotated[str, Argument(help="Target name or ID")]):
         target = self.bbot_server.get_target(target_id)
-        self.print_json(target.model_dump(), highlight=True)
+        self.print_json(target.model_dump(), colorize=True)
 
     def _read_file(self, file, filetype):
         if not file.resolve().is_file():

--- a/bbot_server/utils/async_utils.py
+++ b/bbot_server/utils/async_utils.py
@@ -189,21 +189,28 @@ def async_to_sync_class(cls):
 
                     # Create a synchronous generator that yields from the async generator
                     def sync_generator():
-                        # try:
-                        while True:
-                            # Get the next item from the async generator
-                            coro = async_gen.__anext__()
-                            try:
-                                # Run the coroutine synchronously and yield its result
-                                yield self._wrapper.run_coroutine(coro)
-                            except StopAsyncIteration:
-                                # This is raised when the async generator is exhausted
-                                break
-                        # finally:
-                        #     with suppress(RuntimeError):
-                        #         # Ensure the async generator is properly closed
-                        #         if hasattr(async_gen, "aclose"):
-                        #             self._wrapper.run_coroutine(async_gen.aclose())
+                        try:
+                            while True:
+                                # Get the next item from the async generator
+                                coro = async_gen.__anext__()
+                                try:
+                                    # Run the coroutine synchronously and yield its result
+                                    yield self._wrapper.run_coroutine(coro)
+                                except StopAsyncIteration:
+                                    # Async generator is exhausted – break out of loop
+                                    break
+                        finally:
+                            # Whether the generator finished naturally or was closed early by
+                            # the consumer (e.g. via ``head`` closing the pipe), make sure we
+                            # explicitly close the underlying async generator so that any
+                            # context-manager cleanup (like ``async with httpx.stream``) is
+                            # executed inside the running event loop rather than at GC time.
+                            if hasattr(async_gen, "aclose"):
+                                try:
+                                    self._wrapper.run_coroutine(async_gen.aclose())
+                                except RuntimeError:
+                                    # Event loop already shut down – nothing we can do.
+                                    pass
 
                     # Return the synchronous generator
                     return sync_generator()

--- a/tests/test_applets/test_applet_agents.py
+++ b/tests/test_applets/test_applet_agents.py
@@ -102,7 +102,7 @@ class TestAppletAgents(BaseAppletTest):
 
         agent_dummy_task = asyncio.create_task(agent_dummy())
 
-        await asyncio.sleep(0.1)
+        await asyncio.sleep(1.0)
 
         connected_agents = await self.bbot_server.get_online_agents()
         assert len(connected_agents) == 2

--- a/tests/test_applets/test_applet_stats.py
+++ b/tests/test_applets/test_applet_stats.py
@@ -17,7 +17,7 @@ async def test_applet_stats(bbot_server, bbot_events):
     for _ in range(60):
         # global stats
         global_stats = await bbot_server.get_stats()
-        global_stats_ok = global_stats == {
+        expected_global_stats = {
             "dns_links": {
                 "A": 13,
                 "AAAA": 1,
@@ -68,10 +68,11 @@ async def test_applet_stats(bbot_server, bbot_events):
                 },
             },
         }
+        global_stats_ok = global_stats == expected_global_stats
 
         # by target
         stats_by_target = await bbot_server.get_stats(target_id=target1.id)
-        stats_by_target_ok = stats_by_target == {
+        expected_stats_by_target = {
             "dns_links": {
                 "A": 9,
                 "CNAME": 1,
@@ -115,10 +116,11 @@ async def test_applet_stats(bbot_server, bbot_events):
                 },
             },
         }
+        stats_by_target_ok = stats_by_target == expected_stats_by_target
 
         # by domain
         stats_by_domain = await bbot_server.get_stats(domain="www2.evilcorp.com")
-        stats_by_domain_ok = stats_by_domain == {
+        expected_stats_by_domain = {
             "dns_links": {
                 "A": 2,
             },
@@ -149,6 +151,7 @@ async def test_applet_stats(bbot_server, bbot_events):
                 },
             },
         }
+        stats_by_domain_ok = stats_by_domain == expected_stats_by_domain
 
         if global_stats_ok and stats_by_target_ok and stats_by_domain_ok:
             break
@@ -156,6 +159,4 @@ async def test_applet_stats(bbot_server, bbot_events):
         await asyncio.sleep(0.5)
 
     else:
-        assert False, (
-            f"Stats are not ok. global_stats_ok: {global_stats_ok}, stats_by_target_ok: {stats_by_target_ok}, stats_by_domain_ok: {stats_by_domain_ok}"
-        )
+        assert global_stats 

--- a/tests/test_applets/test_applet_stats.py
+++ b/tests/test_applets/test_applet_stats.py
@@ -159,4 +159,4 @@ async def test_applet_stats(bbot_server, bbot_events):
         await asyncio.sleep(0.5)
 
     else:
-        assert global_stats 
+        assert global_stats

--- a/tests/test_applets/test_applet_stats.py
+++ b/tests/test_applets/test_applet_stats.py
@@ -16,140 +16,146 @@ async def test_applet_stats(bbot_server, bbot_events):
         for e in scan_events:
             await bbot_server.insert_event(e)
 
-    # wait for events to be processed
-    await asyncio.sleep(INGEST_PROCESSING_DELAY)
+    for _ in range(60):
+        # global stats
+        global_stats = await bbot_server.get_stats()
+        global_stats_ok = global_stats == {
+            "dns_links": {
+                "A": 13,
+                "AAAA": 1,
+                "CNAME": 1,
+                "TXT": 8,
+            },
+            "open_ports": {
+                "80": 3,
+                "443": 3,
+            },
+            "technologies": {
+                "cpe:/a:apache:http_server:2.4.12": 2,
+                "cpe:/a:microsoft:internet_information_services": 1,
+            },
+            "cloud_providers": {
+                "Azure": 1,
+                "Amazon": 2,
+            },
+            "findings": {
+                "max_severity": "CRITICAL",
+                "max_severity_score": 5,
+                "names": {
+                    "CVE-2024-12345": 2,
+                    "CVE-2025-54321": 2,
+                },
+                "severities": {
+                    "CRITICAL": 2,
+                    "HIGH": 2,
+                },
+                "counts_by_host": {
+                    "www.evilcorp.com": 1,
+                    "www2.evilcorp.com": 2,
+                    "api.evilcorp.com": 1,
+                },
+                "severities_by_host": {
+                    "www.evilcorp.com": {
+                        "max_severity": "HIGH",
+                        "max_severity_score": 4,
+                    },
+                    "www2.evilcorp.com": {
+                        "max_severity": "CRITICAL",
+                        "max_severity_score": 5,
+                    },
+                    "api.evilcorp.com": {
+                        "max_severity": "CRITICAL",
+                        "max_severity_score": 5,
+                    },
+                },
+            },
+        }
 
-    # global stats
-    stats = await bbot_server.get_stats()
-    assert stats == {
-        "dns_links": {
-            "A": 13,
-            "AAAA": 1,
-            "CNAME": 1,
-            "TXT": 8,
-        },
-        "open_ports": {
-            "80": 3,
-            "443": 3,
-        },
-        "technologies": {
-            "cpe:/a:apache:http_server:2.4.12": 2,
-            "cpe:/a:microsoft:internet_information_services": 1,
-        },
-        "cloud_providers": {
-            "Azure": 1,
-            "Amazon": 2,
-        },
-        "findings": {
-            "max_severity": "CRITICAL",
-            "max_severity_score": 5,
-            "names": {
-                "CVE-2024-12345": 2,
-                "CVE-2025-54321": 2,
+        # by target
+        stats_by_target = await bbot_server.get_stats(target_id=target1.id)
+        stats_by_target_ok = stats_by_target == {
+            "dns_links": {
+                "A": 9,
+                "CNAME": 1,
+                "TXT": 8,
             },
-            "severities": {
-                "CRITICAL": 2,
-                "HIGH": 2,
+            "open_ports": {
+                "80": 2,
+                "443": 3,
             },
-            "counts_by_host": {
-                "www.evilcorp.com": 1,
-                "www2.evilcorp.com": 2,
-                "api.evilcorp.com": 1,
+            "technologies": {
+                "cpe:/a:apache:http_server:2.4.12": 2,
+                "cpe:/a:microsoft:internet_information_services": 1,
             },
-            "severities_by_host": {
-                "www.evilcorp.com": {
-                    "max_severity": "HIGH",
-                    "max_severity_score": 4,
+            "cloud_providers": {
+                "Amazon": 1,
+            },
+            "findings": {
+                "max_severity": "CRITICAL",
+                "max_severity_score": 5,
+                "names": {
+                    "CVE-2024-12345": 1,
+                    "CVE-2025-54321": 2,
                 },
-                "www2.evilcorp.com": {
-                    "max_severity": "CRITICAL",
-                    "max_severity_score": 5,
+                "severities": {
+                    "CRITICAL": 2,
+                    "HIGH": 1,
                 },
-                "api.evilcorp.com": {
-                    "max_severity": "CRITICAL",
-                    "max_severity_score": 5,
+                "counts_by_host": {
+                    "api.evilcorp.com": 1,
+                    "www2.evilcorp.com": 2,
+                },
+                "severities_by_host": {
+                    "api.evilcorp.com": {
+                        "max_severity": "CRITICAL",
+                        "max_severity_score": 5,
+                    },
+                    "www2.evilcorp.com": {
+                        "max_severity": "CRITICAL",
+                        "max_severity_score": 5,
+                    },
                 },
             },
-        },
-    }
+        }
 
-    # by target
-    stats = await bbot_server.get_stats(target_id=target1.id)
-    assert stats == {
-        "dns_links": {
-            "A": 9,
-            "CNAME": 1,
-            "TXT": 8,
-        },
-        "open_ports": {
-            "80": 2,
-            "443": 3,
-        },
-        "technologies": {
-            "cpe:/a:apache:http_server:2.4.12": 2,
-            "cpe:/a:microsoft:internet_information_services": 1,
-        },
-        "cloud_providers": {
-            "Amazon": 1,
-        },
-        "findings": {
-            "max_severity": "CRITICAL",
-            "max_severity_score": 5,
-            "names": {
-                "CVE-2024-12345": 1,
-                "CVE-2025-54321": 2,
+        # by domain
+        stats_by_domain = await bbot_server.get_stats(domain="www2.evilcorp.com")
+        stats_by_domain_ok = stats_by_domain == {
+            "dns_links": {
+                "A": 2,
             },
-            "severities": {
-                "CRITICAL": 2,
-                "HIGH": 1,
+            "open_ports": {
+                "80": 1,
             },
-            "counts_by_host": {
-                "api.evilcorp.com": 1,
-                "www2.evilcorp.com": 2,
-            },
-            "severities_by_host": {
-                "api.evilcorp.com": {
-                    "max_severity": "CRITICAL",
-                    "max_severity_score": 5,
+            "technologies": {},
+            "cloud_providers": {},
+            "findings": {
+                "max_severity": "CRITICAL",
+                "max_severity_score": 5,
+                "names": {
+                    "CVE-2024-12345": 1,
+                    "CVE-2025-54321": 1,
                 },
-                "www2.evilcorp.com": {
-                    "max_severity": "CRITICAL",
-                    "max_severity_score": 5,
+                "severities": {
+                    "CRITICAL": 1,
+                    "HIGH": 1,
+                },
+                "counts_by_host": {
+                    "www2.evilcorp.com": 2,
+                },
+                "severities_by_host": {
+                    "www2.evilcorp.com": {
+                        "max_severity": "CRITICAL",
+                        "max_severity_score": 5,
+                    },
                 },
             },
-        },
-    }
+        }
 
-    # by domain
-    stats = await bbot_server.get_stats(domain="www2.evilcorp.com")
-    assert stats == {
-        "dns_links": {
-            "A": 2,
-        },
-        "open_ports": {
-            "80": 1,
-        },
-        "technologies": {},
-        "cloud_providers": {},
-        "findings": {
-            "max_severity": "CRITICAL",
-            "max_severity_score": 5,
-            "names": {
-                "CVE-2024-12345": 1,
-                "CVE-2025-54321": 1,
-            },
-            "severities": {
-                "CRITICAL": 1,
-                "HIGH": 1,
-            },
-            "counts_by_host": {
-                "www2.evilcorp.com": 2,
-            },
-            "severities_by_host": {
-                "www2.evilcorp.com": {
-                    "max_severity": "CRITICAL",
-                    "max_severity_score": 5,
-                },
-            },
-        },
-    }
+        if global_stats_ok and stats_by_target_ok and stats_by_domain_ok:
+            break
+
+        await asyncio.sleep(0.5)
+
+    else:
+        assert False, f"Stats are not ok. global_stats_ok: {global_stats_ok}, stats_by_target_ok: {stats_by_target_ok}, stats_by_domain_ok: {stats_by_domain_ok}"

--- a/tests/test_applets/test_applet_stats.py
+++ b/tests/test_applets/test_applet_stats.py
@@ -1,7 +1,5 @@
 import asyncio
 
-from ..conftest import INGEST_PROCESSING_DELAY
-
 
 async def test_applet_stats(bbot_server, bbot_events):
     bbot_server = await bbot_server(needs_watchdog=True)
@@ -158,4 +156,6 @@ async def test_applet_stats(bbot_server, bbot_events):
         await asyncio.sleep(0.5)
 
     else:
-        assert False, f"Stats are not ok. global_stats_ok: {global_stats_ok}, stats_by_target_ok: {stats_by_target_ok}, stats_by_domain_ok: {stats_by_domain_ok}"
+        assert False, (
+            f"Stats are not ok. global_stats_ok: {global_stats_ok}, stats_by_target_ok: {stats_by_target_ok}, stats_by_domain_ok: {stats_by_domain_ok}"
+        )


### PR DESCRIPTION
Addresses some of the bugs from the following issues:

- https://github.com/blacklanternsecurity/bbot-server/issues/51
- https://github.com/blacklanternsecurity/bbot-server/issues/40

### Checklist

- [x] Fix traceback error with `| head`
- [x] Associate activities with scans
- [x] Prefer single `api_key` config value before `api_keys` list.
- [x] Case-insensitive API key UUIDs.
- [x] Agent `base_preset` should take precedence over individual scan presets.
- [x] Fix initial cleartext log extension `.log.gz` -> `.log`.
- [ ] Agent's first scan always fails, agent exits without warning or error during python module setup. Second and subsequent scans are fine.
    - Unable to reproduce. This might only happen with certain combinations of modules/configs?
- [ ] Unregistered agent silently fails to work
    - Unable to reproduce. Unregistered agent is rejected with `403`:

```
$ poetry run bbctl agent start -i adfasdgsdf -n ffdsfds
Starting BBOT agent
[INFO] Starting agent
[INFO] Agent ffdsfds connecting to ws://localhost:8807/v1/scans/agents/dock/adfasdgsdf...
[ERROR] Got HTTP 403: (body: bytearray(b''))
[INFO] Agent ffdsfds connecting to ws://localhost:8807/v1/scans/agents/dock/adfasdgsdf...
[ERROR] Got HTTP 403: (body: bytearray(b''))
[INFO] Agent ffdsfds connecting to ws://localhost:8807/v1/scans/agents/dock/adfasdgsdf...
[ERROR] Got HTTP 403: (body: bytearray(b''))
```