### PR TITLE
fix/enhancement: update the update preset function 

### DIFF
--- a/bbot_server/modules/presets/presets_api.py
+++ b/bbot_server/modules/presets/presets_api.py
@@ -45,6 +45,8 @@ class PresetsApplet(BaseApplet):
         # Create new preset with the updated dictionary
         new_preset = Preset(preset=preset)
         new_preset.id = existing_preset.id
+        if not new_preset.name:
+            new_preset.name = existing_preset.name
         new_preset.modified = self.helpers.utc_now()
         try:
             await self.collection.replace_one({"id": str(existing_preset.id)}, new_preset.model_dump())

--- a/bbot_server/modules/presets/presets_cli.py
+++ b/bbot_server/modules/presets/presets_cli.py
@@ -33,10 +33,15 @@ class PresetCTL(BaseBBCTL):
     @subcommand(help="Update a preset by name or ID")
     def update(
         self,
-        id: Annotated[str, Option("--name", "-n", "--id", "-i", help="Preset name or ID")],
         preset: Annotated[Path, Argument(help="Path to preset YAML file")],
+        id: Annotated[str, Option("--name", "-n", "--id", "-i", help="Preset name or ID")] = "",
     ):
         preset_dict = self._load_preset(preset)
+        name_from_config = preset_dict.get("name", "")
+        if not id:
+            if not name_from_config:
+                raise self.BBOTServerValueError("Preset name or ID must be provided via --name/--id or in the preset file")
+            id = name_from_config
         self.bbot_server.update_preset(id, preset_dict)
         self.log.info(f"Preset updated successfully")
 

--- a/bbot_server/modules/presets/presets_cli.py
+++ b/bbot_server/modules/presets/presets_cli.py
@@ -40,7 +40,9 @@ class PresetCTL(BaseBBCTL):
         if not id:
             name_from_config = preset_dict.get("name", "")
             if not name_from_config:
-                raise self.BBOTServerValueError("Preset name or ID must be provided via --name/--id or in the preset file")
+                raise self.BBOTServerValueError(
+                    "Preset name or ID must be provided via --name/--id or in the preset file"
+                )
             id = name_from_config
         self.bbot_server.update_preset(id, preset_dict)
         self.log.info(f"Preset updated successfully")

--- a/bbot_server/modules/presets/presets_cli.py
+++ b/bbot_server/modules/presets/presets_cli.py
@@ -37,8 +37,8 @@ class PresetCTL(BaseBBCTL):
         id: Annotated[str, Option("--name", "-n", "--id", "-i", help="Preset name or ID")] = "",
     ):
         preset_dict = self._load_preset(preset)
-        name_from_config = preset_dict.get("name", "")
         if not id:
+            name_from_config = preset_dict.get("name", "")
             if not name_from_config:
                 raise self.BBOTServerValueError("Preset name or ID must be provided via --name/--id or in the preset file")
             id = name_from_config


### PR DESCRIPTION
This PR addresses a minor bug and offers a slight enhancement in the update preset API + CLI.

- fix: Updating a preset when the preset.yml does not contain a `name` field will remove the name entirely. This will err on subsequent updates as it the provided name can no longer be found.
- enhancement: `--name`/`--id` is now optional for the CLI command `bbctl scan preset update`. If a name is provided in the .yml, it will be used. Otherwise error as no name/id is provided.

I've attempted to maintain the intended "rename" feature, where if a name is provided in both the CLI flag and yml, then the flag is used to query the preset, and the yml name would be used as the new name.

Was unable to run the pytest (unable to start server? not sure why), but I tested with `docker run` + `bbctl` commands manually.

### Steps to Reproduce

To reproduce the bug:

```
bbctl server start --api-only
```

preset.yml
```yml
description: test
```

```sh
bbctl scan preset create preset.yml -n preset
# ok
bbctl scan preset update preset.yml -n preset
# updated successfully
bbctl scan preset update preset.yml -n preset
# preset not found: {'name': 'preset'}
```

<img width="921" height="243" alt="image" src="https://github.com/user-attachments/assets/8c871b94-b481-45e0-bac5-0c03cc42a232" />

