### PR TITLE
Better search

### DIFF
--- a/bbot_server/applets/base.py
+++ b/bbot_server/applets/base.py
@@ -419,7 +419,6 @@ class BaseApplet:
         target_id = target_id or None
         type = type or None
         host = host or None
-        search = search or None
 
         if ("type" not in query) and (type is not None):
             query["type"] = type
@@ -429,8 +428,6 @@ class BaseApplet:
             reversed_host = re.escape(domain[::-1])
             # Match exact domain or subdomains (with dot separator)
             query["reverse_host"] = {"$regex": f"^{reversed_host}(\\.|$)"}
-        if ("$text" not in query) and (search is not None):
-            query["$text"] = {"$search": search}
 
         # timestamps
         if "timestamp" not in query and (min_timestamp is not None or max_timestamp is not None):
@@ -471,7 +468,28 @@ class BaseApplet:
             # only one should be true
             query["archived"] = {"$eq": archived}
 
+        if search:
+            search_query = await self.make_search_query(search)
+            if search_query:
+                query = {"$and": [query, search_query]}
+
         return _sanitize_mongo_query(query)
+
+    async def make_search_query(self, search: str):
+        """
+        Given a search term, construct a human-friendly search against multiple fields.
+        """
+        search_str = re.escape(search.strip().lower())
+        if not search_str:
+            return None
+        return {
+            "$or": [
+                {"$text": {"$search": search_str}},
+                {"host_parts": {"$regex": f"^{search_str}"}},
+                {"host": {"$regex": f"^{search_str}$"}},
+                {"reverse_host": {"$regex": f"^{search_str[::-1]}$"}},
+            ]
+        }
 
     async def mongo_iter(self, *args, **kwargs):
         """

--- a/bbot_server/modules/activity/activity_api.py
+++ b/bbot_server/modules/activity/activity_api.py
@@ -33,7 +33,9 @@ class ActivityApplet(BaseApplet):
     async def query_activities(
         self,
         query: Annotated[dict, Body(description="Raw mongo query")] = None,
-        search: Annotated[str, Body(description="Search using mongo's text index")] = None,
+        search: Annotated[
+            str, Body(description="A human-friendly text search (will be ANDed with other filters)")
+        ] = None,
         host: Annotated[str, Body(description="Filter activities by host (exact match only)")] = None,
         domain: Annotated[str, Body(description="Filter activities by domain (subdomains allowed)")] = None,
         type: Annotated[str, Body(description="Filter activities by type")] = None,
@@ -70,7 +72,9 @@ class ActivityApplet(BaseApplet):
     async def count_activities(
         self,
         query: Annotated[dict, Body(description="Raw mongo query")] = None,
-        search: Annotated[str, Body(description="Search using mongo's text index")] = None,
+        search: Annotated[
+            str, Body(description="A human-friendly text search (will be ANDed with other filters)")
+        ] = None,
         host: Annotated[str, Body(description="Filter activities by host (exact match only)")] = None,
         domain: Annotated[str, Body(description="Filter activities by domain (subdomains allowed)")] = None,
         type: Annotated[str, Body(description="Filter activities by type")] = None,

--- a/bbot_server/modules/assets/assets_api.py
+++ b/bbot_server/modules/assets/assets_api.py
@@ -29,7 +29,9 @@ class AssetsApplet(BaseApplet):
     async def query_assets(
         self,
         query: Annotated[dict, Body(description="Raw mongo query")] = None,
-        search: Annotated[str, Body(description="Search using mongo's text index")] = None,
+        search: Annotated[
+            str, Body(description="A human-friendly text search (will be ANDed with other filters)")
+        ] = None,
         host: Annotated[str, Body(description="Filter assets by host (exact match only)")] = None,
         domain: Annotated[str, Body(description="Filter assets by domain (subdomains allowed)")] = None,
         type: Annotated[
@@ -70,7 +72,9 @@ class AssetsApplet(BaseApplet):
     async def count_assets(
         self,
         query: Annotated[dict, Body(description="Raw mongo query")] = None,
-        search: Annotated[str, Body(description="Search using mongo's text index")] = None,
+        search: Annotated[
+            str, Body(description="A human-friendly text search (will be ANDed with other filters)")
+        ] = None,
         host: Annotated[str, Body(description="Filter assets by host (exact match only)")] = None,
         domain: Annotated[str, Body(description="Filter assets by domain (subdomains allowed)")] = None,
         type: Annotated[

--- a/bbot_server/modules/events/events_api.py
+++ b/bbot_server/modules/events/events_api.py
@@ -66,7 +66,9 @@ class EventsApplet(BaseApplet):
     async def query_events(
         self,
         query: Annotated[dict, Body(description="Raw mongo query")] = None,
-        search: Annotated[str, Body(description="Search using mongo's text index")] = None,
+        search: Annotated[
+            str, Body(description="A human-friendly text search (will be ANDed with other filters)")
+        ] = None,
         host: Annotated[str, Body(description="Filter by exact hostname or IP address")] = None,
         domain: Annotated[str, Body(description="Filter by domain or subdomain")] = None,
         target_id: Annotated[str, Body(description="Filter by target name or id")] = None,
@@ -105,7 +107,9 @@ class EventsApplet(BaseApplet):
     async def count_events(
         self,
         query: Annotated[dict, Body(description="Raw mongo query")] = None,
-        search: Annotated[str, Body(description="Search using mongo's text index")] = None,
+        search: Annotated[
+            str, Body(description="A human-friendly text search (will be ANDed with other filters)")
+        ] = None,
         host: Annotated[str, Body(description="Filter by exact hostname or IP address")] = None,
         domain: Annotated[str, Body(description="Filter by domain or subdomain")] = None,
         target_id: Annotated[str, Body(description="Filter by target name or id")] = None,

--- a/bbot_server/modules/findings/findings_api.py
+++ b/bbot_server/modules/findings/findings_api.py
@@ -67,7 +67,9 @@ class FindingsApplet(BaseApplet):
     async def query_findings(
         self,
         query: Annotated[dict, Body(description="Raw mongo query")] = None,
-        search: Annotated[str, Body(description="Search using mongo's text index")] = None,
+        search: Annotated[
+            str, Body(description="A human-friendly text search (will be ANDed with other filters)")
+        ] = None,
         host: Annotated[str, Body(description="Filter by exact hostname or IP address")] = None,
         domain: Annotated[str, Body(description="Filter by domain or subdomain")] = None,
         target_id: Annotated[str, Body(description="Filter by target name or id")] = None,
@@ -112,7 +114,9 @@ class FindingsApplet(BaseApplet):
     async def count_findings(
         self,
         query: Annotated[dict, Body(description="Raw mongo query")] = None,
-        search: Annotated[str, Body(description="Search using mongo's text index")] = None,
+        search: Annotated[
+            str, Body(description="A human-friendly text search (will be ANDed with other filters)")
+        ] = None,
         host: Annotated[str, Body(description="Filter by exact hostname or IP address")] = None,
         domain: Annotated[str, Body(description="Filter by domain or subdomain")] = None,
         target_id: Annotated[str, Body(description="Filter by target name or id")] = None,

--- a/bbot_server/modules/technologies/technologies_api.py
+++ b/bbot_server/modules/technologies/technologies_api.py
@@ -34,7 +34,9 @@ class TechnologiesApplet(BaseApplet):
         domain: str = None,
         host: str = None,
         technology: Annotated[str, Query(description="filter by technology (must match exactly)")] = None,
-        search: Annotated[str, Query(description="search for a technology (fuzzy match)")] = None,
+        search: Annotated[
+            str, Query(description="A human-friendly text search (will be ANDed with other filters)")
+        ] = None,
         target_id: Annotated[str, Query(description="filter by target (can be either name or ID)")] = None,
         archived: Annotated[bool, Query(description="whether to include archived technologies")] = False,
         active: Annotated[bool, Query(description="whether to include active (non-archived) technologies")] = True,
@@ -57,7 +59,9 @@ class TechnologiesApplet(BaseApplet):
         self,
         query: Annotated[dict, Body(description="Raw mongo query")] = None,
         technology: Annotated[str, Body(description="filter by technology (must match exactly)")] = None,
-        search: Annotated[str, Body(description="search for a technology (fuzzy match)")] = None,
+        search: Annotated[
+            str, Body(description="A human-friendly text search (will be ANDed with other filters)")
+        ] = None,
         host: Annotated[str, Body(description="filter by host (exact match only)")] = None,
         domain: Annotated[str, Body(description="filter by domain (subdomains allowed)")] = None,
         target_id: Annotated[str, Body(description="filter by target (can be either name or ID)")] = None,

--- a/tests/test_applets/test_applet_assets.py
+++ b/tests/test_applets/test_applet_assets.py
@@ -194,6 +194,23 @@ class TestAppletAssets(BaseAppletTest):
         assets = [a async for a in self.bbot_server.query_assets(query=query)]
         assert {a["host"] for a in assets} == {"t1.tech.evilcorp.com", "t2.tech.evilcorp.com"}
 
+        # test text search feature
+        assets = [a async for a in self.bbot_server.query_assets(search="tec")]
+        assert {a["host"] for a in assets} == {"t1.tech.evilcorp.com", "t2.tech.evilcorp.com"}
+        assets = [a async for a in self.bbot_server.query_assets(search="evilcor")]
+        assert {a["host"] for a in assets} == {
+            "api.evilcorp.com",
+            "cname.evilcorp.com",
+            "evilcorp.amazonaws.com",
+            "evilcorp.azure.com",
+            "evilcorp.com",
+            "localhost.evilcorp.com",
+            "t1.tech.evilcorp.com",
+            "t2.tech.evilcorp.com",
+            "www.evilcorp.com",
+            "www2.evilcorp.com",
+        }
+
     async def after_archive(self):
         assert set(await self.bbot_server.get_hosts()) == {
             "1.2.3.4",


### PR DESCRIPTION
Updates the `search=` param to be more human-friendly and intuitive. Instead of only using mongo's `$text` search, it now also searches `host`, `reverse_host`, and `host_parts`. The `make_search_query()` method can be overridden to provide customized search features to a certain applet.

Addresses https://github.com/blacklanternsecurity/bbot-server/issues/84.