### PR TITLE
Helpers for Custom FastAPI Routers

### DIFF
--- a/bbot_server/applets/_routing.py
+++ b/bbot_server/applets/_routing.py
@@ -35,6 +35,14 @@ def _patch_websocket_signature(original_function, wrapper_function):
     )
 
 
+def fastapi_wrap(function):
+    """
+    Convenience helper for turning a BBOT Server applet method into a FastAPI-ready function
+    """
+    route = make_bbotserver_route(function)
+    return route.wrapped_function()
+
+
 def make_bbotserver_route(function, tags=[]):
     """
     Given a BBOTServer applet method, add it to a FastAPI app as a route.
@@ -57,7 +65,7 @@ def make_bbotserver_route(function, tags=[]):
         route_class = ROUTE_TYPES[endpoint_type]
     except KeyError:
         raise BBOTServerValueError(f"Invalid endpoint type: {endpoint_type}")
-    
+
     return route_class(function, tags=tags)
 
 
@@ -79,23 +87,31 @@ class BaseServerRoute(metaclass=ServerRouteMeta):
 
     def __init__(self, function, tags=[]):
         self.log = logging.getLogger(f"bbot_server.routing.{self.__class__.__name__.lower()}")
-        self.function = function
-        self.path = getattr(function, "_endpoint", None)
-        if self.path is None:
-            raise BBOTServerValueError(f"Function {function.__name__} does not have an _endpoint attribute")
-        self.function_signature = inspect.signature(self.function)
+        self.orig_function = function
+        self.function_signature = inspect.signature(self.orig_function)
+
+        self.function = self.wrapped_function()
+        self.default_path = getattr(self.orig_function, "_endpoint", None)
 
         # these are the kwargs specified in the @api_endpoint decorator
         # they are fastapi kwargs with a few extra ones which we'll pop off here
-        self.kwargs = dict(getattr(self.function, "_kwargs", {}))
+        self.kwargs = dict(getattr(self.orig_function, "_kwargs", {}))
         self.kwargs.pop("type", None)
         self.response_model = self.kwargs.pop("response_model", None)
         if self.requires_response_model and self.response_model is None:
-            raise BBOTServerValueError(f"Function {function.__name__} {self.path}: Must specify a pydantic model used for deserializing {self.endpoint_type} streams")
+            raise BBOTServerValueError(
+                f"Function {function.__name__}: Must specify a pydantic model used for deserializing {self.endpoint_type} streams"
+            )
         self.mcp = self.kwargs.pop("mcp", False)
         if self.mcp:
-            MCP_ENDPOINTS[self.function_name] = self.function
+            MCP_ENDPOINTS[self.function_name] = self.orig_function
         self.tags = tags
+
+    def wrapped_function(self):
+        """
+        Optionally wrap the function for optimal compatability with fastapi's routing system
+        """
+        return self.orig_function
 
     @property
     def function_name(self):
@@ -118,18 +134,18 @@ class BaseServerRoute(metaclass=ServerRouteMeta):
         """
         raise NotImplementedError("Subclasses must implement this method")
 
-    def _add_api_route(self, router, function, path=None, websocket=False, **fastapi_kwargs):
+    def _add_api_route(self, router, path=None, websocket=False, **fastapi_kwargs):
         path, kwargs = self._prepare_fastapi_kwargs(path=path, **fastapi_kwargs)
         if not "operation_id" in kwargs:
             kwargs["operation_id"] = self.function_name
         if not "tags" in kwargs:
             kwargs["tags"] = self.tags
-        router.add_api_route(path, function, **kwargs)
+        router.add_api_route(path, self.wrapped_function(), **kwargs)
 
-    def _add_api_websocket_route(self, router, function, path=None, **fastapi_kwargs):
+    def _add_api_websocket_route(self, router, path=None, **fastapi_kwargs):
         path, kwargs = self._prepare_fastapi_kwargs(path=path, **fastapi_kwargs)
         kwargs.pop("summary", None)
-        router.add_api_websocket_route(path, function, **kwargs)
+        router.add_api_websocket_route(path, self.wrapped_function(), **kwargs)
 
     def _prepare_fastapi_kwargs(self, **fastapi_kwargs):
         """
@@ -137,7 +153,7 @@ class BaseServerRoute(metaclass=ServerRouteMeta):
         """
         kwargs = dict(self.kwargs)
         kwargs.update(fastapi_kwargs)
-        path = kwargs.pop("path", None) or self.path
+        path = kwargs.pop("path", None) or self.default_path
         return path, kwargs
 
     def setup(self):
@@ -157,7 +173,7 @@ class HTTPRoute(BaseServerRoute):
     endpoint_type = "http"
 
     def add_to_router(self, router, **fastapi_kwargs):
-        self._add_api_route(router, self.function, **fastapi_kwargs)
+        self._add_api_route(router, **fastapi_kwargs)
 
     def setup(self):
         self.response_model = self.fastapi_route.response_model
@@ -171,17 +187,15 @@ class HTTPStreamRoute(BaseServerRoute):
     endpoint_type = "http_stream"
     requires_response_model = True
 
-    def add_to_router(self, router, **fastapi_kwargs):
+    def wrapped_function(self):
         """
         Here we convert a python async generator into a StreamingResponse
         """
 
-        # Get the function signature
-        sig = inspect.signature(self.function)
-
         # Define a new async function that wraps the original function
+        @functools.wraps(self.orig_function)
         async def wrapper(*args, **kwargs):
-            generator = self.function(*args, **kwargs)
+            generator = self.orig_function(*args, **kwargs)
 
             try:
                 # Trigger execution by getting the first item
@@ -199,10 +213,10 @@ class HTTPStreamRoute(BaseServerRoute):
             return StreamingResponse(async_generator())
 
         # Set the wrapper's signature to match the original function
-        wrapper.__signature__ = sig
+        return wrapper
 
-        # Add the route
-        self._add_api_route(router, wrapper, **fastapi_kwargs)
+    def add_to_router(self, router, **fastapi_kwargs):
+        self._add_api_route(router, **fastapi_kwargs)
 
 
 class WebsocketRoute(BaseServerRoute):
@@ -212,8 +226,8 @@ class WebsocketRoute(BaseServerRoute):
 
     endpoint_type = "websocket"
 
-    def add_to_router(self, router, **fastapi_kwargs):
-        @functools.wraps(self.function)
+    def wrapped_function(self):
+        @functools.wraps(self.orig_function)
         async def websocket_auth_wrapper(websocket: WebSocket, *args, **kwargs):
             await websocket.accept()
             api_key = websocket.headers.get(bbcfg.API_KEY_NAME, "")
@@ -224,8 +238,10 @@ class WebsocketRoute(BaseServerRoute):
                 await websocket.close(code=1008, reason=reason)
 
         # _patch_websocket_signature(self.function, websocket_auth_wrapper)
+        return websocket_auth_wrapper
 
-        self._add_api_websocket_route(router, websocket_auth_wrapper, **fastapi_kwargs)
+    def add_to_router(self, router, **fastapi_kwargs):
+        self._add_api_websocket_route(router, **fastapi_kwargs)
 
 
 class WebsocketStreamOutgoingRoute(BaseServerRoute):
@@ -236,8 +252,8 @@ class WebsocketStreamOutgoingRoute(BaseServerRoute):
     endpoint_type = "websocket_stream_outgoing"
     requires_response_model = True
 
-    def add_to_router(self, router, **fastapi_kwargs):
-        @functools.wraps(self.function)
+    def wrapped_function(self):
+        @functools.wraps(self.orig_function)
         async def websocket_wrapper(websocket: WebSocket, *args, **kwargs):
             """
             Handles opening and closing of the websocket, allowing the user-defined function to be a simple async generator
@@ -248,7 +264,7 @@ class WebsocketStreamOutgoingRoute(BaseServerRoute):
                 valid, reason = bbcfg.check_api_key(api_key)
                 if not valid:
                     await websocket.close(code=3000, reason=reason)
-                agen = self.function(*args, **kwargs)
+                agen = self.orig_function(*args, **kwargs)
                 async for message in agen:
                     message = smart_encode(message)
                     await websocket.send_bytes(message)
@@ -263,9 +279,11 @@ class WebsocketStreamOutgoingRoute(BaseServerRoute):
                     await agen.aclose()
 
         # Use the helper function to set the signature
-        _patch_websocket_signature(self.function, websocket_wrapper)
+        _patch_websocket_signature(self.orig_function, websocket_wrapper)
+        return websocket_wrapper
 
-        self._add_api_websocket_route(router, websocket_wrapper, **fastapi_kwargs)
+    def add_to_router(self, router, **fastapi_kwargs):
+        self._add_api_websocket_route(router, **fastapi_kwargs)
 
 
 class WebsocketStreamIncomingRoute(BaseServerRoute):
@@ -280,6 +298,9 @@ class WebsocketStreamIncomingRoute(BaseServerRoute):
         super().__init__(function, **kwargs)
         # we blank out the function signature
         self.function_signature = inspect.Signature(parameters=[], return_annotation=None)
+
+    def wrapped_function(self):
+        return self.websocket_wrapper
 
     async def websocket_wrapper(self, websocket: WebSocket):
         try:
@@ -304,10 +325,10 @@ class WebsocketStreamIncomingRoute(BaseServerRoute):
                 except RuntimeError as e:
                     log.error(f"Unexpected error in websocket stream: {e}")
 
-            await self.function(agen())
+            await self.orig_function(agen())
         finally:
             with suppress(BaseException):
                 await websocket.close()
 
     def add_to_router(self, router, **fastapi_kwargs):
-        self._add_api_websocket_route(router, self.websocket_wrapper, **fastapi_kwargs)
+        self._add_api_websocket_route(router, **fastapi_kwargs)

--- a/bbot_server/applets/_routing.py
+++ b/bbot_server/applets/_routing.py
@@ -115,7 +115,7 @@ class BaseServerRoute(metaclass=ServerRouteMeta):
 
     @property
     def function_name(self):
-        return self.function.__name__
+        return self.orig_function.__name__
 
     def add_to_applet(self, applet):
         """

--- a/bbot_server/applets/_routing.py
+++ b/bbot_server/applets/_routing.py
@@ -10,6 +10,7 @@ from starlette.websockets import WebSocketDisconnect
 import bbot_server.config as bbcfg
 from bbot_server.api.mcp import MCP_ENDPOINTS
 from bbot_server.utils.misc import smart_encode
+from bbot_server.errors import BBOTServerValueError
 
 
 log = logging.getLogger("bbot_server.applets.routing")
@@ -34,6 +35,32 @@ def _patch_websocket_signature(original_function, wrapper_function):
     )
 
 
+def make_bbotserver_route(function, tags=[]):
+    """
+    Given a BBOTServer applet method, add it to a FastAPI app as a route.
+
+    Args:
+        function: The BBOTServer applet method to add to the FastAPI app.
+        **fastapi_kwargs: Additional keyword arguments to pass to the FastAPI app. These will override any arguments specified in the @api_endpoint decorator.
+    """
+    # see if the value has an "_endpoint" attribute
+    path = getattr(function, "_endpoint", None)
+    # if it's a callable function and it has _endpoint, it's an @api_endpoint
+
+    if path is None:
+        raise BBOTServerValueError(f"Function {function.__name__} does not have an _endpoint attribute")
+
+    endpoint_kwargs = dict(getattr(function, "_kwargs", {}))
+    endpoint_type = endpoint_kwargs.pop("type", "http")
+
+    try:
+        route_class = ROUTE_TYPES[endpoint_type]
+    except KeyError:
+        raise BBOTServerValueError(f"Invalid endpoint type: {endpoint_type}")
+    
+    return route_class(function, tags=tags)
+
+
 class ServerRouteMeta(type):
     """Metaclass for registering BaseServerRoute subclasses"""
 
@@ -53,10 +80,18 @@ class BaseServerRoute(metaclass=ServerRouteMeta):
     def __init__(self, function, tags=[]):
         self.log = logging.getLogger(f"bbot_server.routing.{self.__class__.__name__.lower()}")
         self.function = function
-        self.endpoint = getattr(function, "_endpoint", None)
-        self.function_signature = inspect.signature(function)
-        self.kwargs = dict(getattr(function, "_kwargs", {}))
-        self.kwargs.pop("type", "")
+        self.path = getattr(function, "_endpoint", None)
+        if self.path is None:
+            raise BBOTServerValueError(f"Function {function.__name__} does not have an _endpoint attribute")
+        self.function_signature = inspect.signature(self.function)
+
+        # these are the kwargs specified in the @api_endpoint decorator
+        # they are fastapi kwargs with a few extra ones which we'll pop off here
+        self.kwargs = dict(getattr(self.function, "_kwargs", {}))
+        self.kwargs.pop("type", None)
+        self.response_model = self.kwargs.pop("response_model", None)
+        if self.requires_response_model and self.response_model is None:
+            raise BBOTServerValueError(f"Function {function.__name__} {self.path}: Must specify a pydantic model used for deserializing {self.endpoint_type} streams")
         self.mcp = self.kwargs.pop("mcp", False)
         if self.mcp:
             MCP_ENDPOINTS[self.function_name] = self.function
@@ -67,12 +102,43 @@ class BaseServerRoute(metaclass=ServerRouteMeta):
         return self.function.__name__
 
     def add_to_applet(self, applet):
+        """
+        Add this BBOT Server route to the given applet's FastAPI router
+        """
         self.add_to_router(applet.router)
         self.fastapi_route = applet.router.routes[-1]
         self.path = self.fastapi_route.path
         self.full_path = f"{applet.full_prefix()}{self.fastapi_route.path}"
         applet.route_maps[self.function_name] = self
         self.setup()
+
+    def add_to_router(self, router, **fastapi_kwargs):
+        """
+        Add this BBOT Server route to the given FastAPI router
+        """
+        raise NotImplementedError("Subclasses must implement this method")
+
+    def _add_api_route(self, router, function, path=None, websocket=False, **fastapi_kwargs):
+        path, kwargs = self._prepare_fastapi_kwargs(path=path, **fastapi_kwargs)
+        if not "operation_id" in kwargs:
+            kwargs["operation_id"] = self.function_name
+        if not "tags" in kwargs:
+            kwargs["tags"] = self.tags
+        router.add_api_route(path, function, **kwargs)
+
+    def _add_api_websocket_route(self, router, function, path=None, **fastapi_kwargs):
+        path, kwargs = self._prepare_fastapi_kwargs(path=path, **fastapi_kwargs)
+        kwargs.pop("summary", None)
+        router.add_api_websocket_route(path, function, **kwargs)
+
+    def _prepare_fastapi_kwargs(self, **fastapi_kwargs):
+        """
+        Fills in any necessary missing defaults in the FastAPI kwargs
+        """
+        kwargs = dict(self.kwargs)
+        kwargs.update(fastapi_kwargs)
+        path = kwargs.pop("path", None) or self.path
+        return path, kwargs
 
     def setup(self):
         pass
@@ -90,12 +156,8 @@ class HTTPRoute(BaseServerRoute):
 
     endpoint_type = "http"
 
-    def __init__(self, function, tags=[]):
-        super().__init__(function, tags)
-        self.kwargs["tags"] = self.tags
-
-    def add_to_router(self, router):
-        router.add_api_route(self.endpoint, self.function, operation_id=self.function.__name__, **self.kwargs)
+    def add_to_router(self, router, **fastapi_kwargs):
+        self._add_api_route(router, self.function, **fastapi_kwargs)
 
     def setup(self):
         self.response_model = self.fastapi_route.response_model
@@ -109,12 +171,7 @@ class HTTPStreamRoute(BaseServerRoute):
     endpoint_type = "http_stream"
     requires_response_model = True
 
-    def __init__(self, function, response_model, tags=[]):
-        super().__init__(function, tags)
-        self.kwargs["tags"] = self.tags
-        self.response_model = response_model
-
-    def add_to_router(self, router):
+    def add_to_router(self, router, **fastapi_kwargs):
         """
         Here we convert a python async generator into a StreamingResponse
         """
@@ -145,7 +202,7 @@ class HTTPStreamRoute(BaseServerRoute):
         wrapper.__signature__ = sig
 
         # Add the route
-        router.add_api_route(self.endpoint, wrapper, operation_id=self.function.__name__, **self.kwargs)
+        self._add_api_route(router, wrapper, **fastapi_kwargs)
 
 
 class WebsocketRoute(BaseServerRoute):
@@ -155,7 +212,7 @@ class WebsocketRoute(BaseServerRoute):
 
     endpoint_type = "websocket"
 
-    def add_to_router(self, router):
+    def add_to_router(self, router, **fastapi_kwargs):
         @functools.wraps(self.function)
         async def websocket_auth_wrapper(websocket: WebSocket, *args, **kwargs):
             await websocket.accept()
@@ -168,7 +225,7 @@ class WebsocketRoute(BaseServerRoute):
 
         # _patch_websocket_signature(self.function, websocket_auth_wrapper)
 
-        router.add_api_websocket_route(self.endpoint, websocket_auth_wrapper, **self.kwargs)
+        self._add_api_websocket_route(router, websocket_auth_wrapper, **fastapi_kwargs)
 
 
 class WebsocketStreamOutgoingRoute(BaseServerRoute):
@@ -179,11 +236,7 @@ class WebsocketStreamOutgoingRoute(BaseServerRoute):
     endpoint_type = "websocket_stream_outgoing"
     requires_response_model = True
 
-    def __init__(self, function, response_model, tags=[]):
-        super().__init__(function, tags)
-        self.response_model = response_model
-
-    def add_to_router(self, router):
+    def add_to_router(self, router, **fastapi_kwargs):
         @functools.wraps(self.function)
         async def websocket_wrapper(websocket: WebSocket, *args, **kwargs):
             """
@@ -212,7 +265,7 @@ class WebsocketStreamOutgoingRoute(BaseServerRoute):
         # Use the helper function to set the signature
         _patch_websocket_signature(self.function, websocket_wrapper)
 
-        router.add_api_websocket_route(self.endpoint, websocket_wrapper)
+        self._add_api_websocket_route(router, websocket_wrapper, **fastapi_kwargs)
 
 
 class WebsocketStreamIncomingRoute(BaseServerRoute):
@@ -223,9 +276,8 @@ class WebsocketStreamIncomingRoute(BaseServerRoute):
     endpoint_type = "websocket_stream_incoming"
     requires_response_model = True
 
-    def __init__(self, function, response_model, tags=[]):
-        super().__init__(function, tags)
-        self.response_model = response_model
+    def __init__(self, function, **kwargs):
+        super().__init__(function, **kwargs)
         # we blank out the function signature
         self.function_signature = inspect.Signature(parameters=[], return_annotation=None)
 
@@ -257,5 +309,5 @@ class WebsocketStreamIncomingRoute(BaseServerRoute):
             with suppress(BaseException):
                 await websocket.close()
 
-    def add_to_router(self, router):
-        router.add_api_websocket_route(self.endpoint, self.websocket_wrapper)
+    def add_to_router(self, router, **fastapi_kwargs):
+        self._add_api_websocket_route(router, self.websocket_wrapper, **fastapi_kwargs)

--- a/bbot_server/applets/_routing.py
+++ b/bbot_server/applets/_routing.py
@@ -233,7 +233,7 @@ class WebsocketRoute(BaseServerRoute):
             api_key = websocket.headers.get(bbcfg.API_KEY_NAME, "")
             valid, reason = bbcfg.check_api_key(api_key)
             if valid:
-                await self.function(websocket, *args, **kwargs)
+                await self.orig_function(websocket, *args, **kwargs)
             else:
                 await websocket.close(code=1008, reason=reason)
 

--- a/bbot_server/applets/base.py
+++ b/bbot_server/applets/base.py
@@ -642,7 +642,7 @@ class BaseApplet:
             function = getattr(self, attr, None)
             if not callable(function):
                 continue
-            
+
             if not hasattr(function, "_endpoint"):
                 continue
 

--- a/bbot_server/applets/base.py
+++ b/bbot_server/applets/base.py
@@ -15,8 +15,8 @@ from bbot_server.assets import Asset
 from bbot.models.pydantic import Event
 from bbot_server.modules import API_MODULES
 from bbot.core.helpers import misc as bbot_misc
-from bbot_server.applets._routing import ROUTE_TYPES
 from bbot_server.utils import misc as bbot_server_misc
+from bbot_server.applets._routing import make_bbotserver_route
 from bbot_server.modules.activity.activity_models import Activity
 from bbot_server.errors import BBOTServerError, BBOTServerValueError
 from bbot_server.utils.misc import _sanitize_mongo_query, _sanitize_mongo_aggregation
@@ -642,31 +642,15 @@ class BaseApplet:
             function = getattr(self, attr, None)
             if not callable(function):
                 continue
-            # see if the value has an "_endpoint" attribute
-            endpoint = getattr(function, "_endpoint", None)
-            # if it's a callable function and it has _endpoint, it's an @api_endpoint
+            
+            if not hasattr(function, "_endpoint"):
+                continue
 
-            if endpoint is not None:
-                fastapi_kwargs = dict(getattr(function, "_kwargs", {}))
-                endpoint_type = fastapi_kwargs.pop("type", "http")
-                response_model = fastapi_kwargs.pop("response_model", None)
-
-                try:
-                    route_class = ROUTE_TYPES[endpoint_type]
-                except KeyError:
-                    raise self.BBOTServerError(f"Invalid endpoint type: {endpoint_type}")
-
-                kwargs = {"tags": [self.tag]}
-
-                if route_class.requires_response_model:
-                    if response_model is None:
-                        raise self.BBOTServerError(
-                            f"{self.name}.{function.__name__} {endpoint}: Must specify a pydantic model used for deserializing {endpoint_type} streams"
-                        )
-                    kwargs["response_model"] = response_model
-
-                bbot_server_route = route_class(function, **kwargs)
-                bbot_server_route.add_to_applet(self)
+            try:
+                bbot_server_route = make_bbotserver_route(function, tags=[self.tag])
+            except BBOTServerValueError:
+                continue
+            bbot_server_route.add_to_applet(self)
 
     @property
     def global_config(self):


### PR DESCRIPTION
This PR defragments the routing logic to make it easier to add BBOT server methods to your own FastAPI routers.

```python
import uvicorn
from fastapi import FastAPI
from contextlib import asynccontextmanager
from bbot_server import BBOTServer
from bbot_server.applets._routing import fastapi_wrap

bbot_server = BBOTServer()

@asynccontextmanager
async def lifespan(app: FastAPI):
    await bbot_server.setup()
    yield

app = FastAPI(lifespan=lifespan)
app.add_api_route("/assets", fastapi_wrap(bbot_server.list_assets), methods=["GET"])
app.add_api_route("/events", fastapi_wrap(bbot_server.list_events), methods=["GET"])

if __name__ == "__main__":
    uvicorn.run(app, host="0.0.0.0", port=8000)
```

`fastapi_wrap()` is needed because BBOT server is a python API first, and needs thin wrappers e.g. to turn async generators into a StreamingResponse compatible with FastAPI.