### PR TITLE
Scan status fix

### DIFF
--- a/bbot_server/modules/scans/scans_api.py
+++ b/bbot_server/modules/scans/scans_api.py
@@ -283,6 +283,7 @@ class ScansApplet(BaseApplet):
         except self.BBOTServerNotFoundError:
             existing_scan = None
         existing_status_code = get_scan_status_code(getattr(existing_scan, "status_code", SCAN_STATUS_QUEUED))
+        status_changed = False
         # if the scan already exists, update it
         if existing_scan:
             # ignore if the new status is at or behind the existing one

--- a/bbot_server/modules/scans/scans_api.py
+++ b/bbot_server/modules/scans/scans_api.py
@@ -283,7 +283,6 @@ class ScansApplet(BaseApplet):
         except self.BBOTServerNotFoundError:
             existing_scan = None
         existing_status_code = get_scan_status_code(getattr(existing_scan, "status_code", SCAN_STATUS_QUEUED))
-        status_changed = False
         # if the scan already exists, update it
         if existing_scan:
             # ignore if the new status is at or behind the existing one
@@ -309,6 +308,7 @@ class ScansApplet(BaseApplet):
                 status_changed = await self.update_scan_status(scan_id=scan_id, status_code=scan.status_code)
             else:
                 self.log.warning(f'Scan "{scan.name}" found in database, but event has no duration_seconds')
+                status_changed = False
         # otherwise, assume the scan is starting and create a new run
         else:
             description = f"Scan [[COLOR]{scan.name}[/COLOR]] started"


### PR DESCRIPTION
Fixes this bug:

```
watchdog-1  | [ERROR] Error ingesting event SCAN for applet Scans: cannot access local variable 'status_changed' where it is not associated with a value
watchdog-1  | [ERROR] Traceback (most recent call last):
watchdog-1  |   File "/app/bbot_server/watchdog/worker.py", line 86, in _event_listener
watchdog-1  |     _activities = await applet.handle_event(event, asset) or []
watchdog-1  |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
watchdog-1  |   File "/app/bbot_server/modules/scans/scans_api.py", line 318, in handle_event
watchdog-1  |     if status_changed:
watchdog-1  |        ^^^^^^^^^^^^^^
watchdog-1  | UnboundLocalError: cannot access local variable 'status_changed' where it is not associated with a value
watchdog-1  |
```