### PR TITLE
New asset fix

### DIFF
--- a/bbot_server/modules/targets/targets_api.py
+++ b/bbot_server/modules/targets/targets_api.py
@@ -127,7 +127,7 @@ class TargetsApplet(BaseApplet):
         """
         Given a host, get all the targets it's a part of
         """
-        asset = await self.root.assets.collection.find_one({"host": host}, {"dns_links": 1})
+        asset = await self.root.assets.collection.find_one({"host": host}, {"dns_links": 1}) or {}
         asset_dns_links = asset.get("dns_links", {})
         asset_scope = []
         for target_id in await self.get_target_ids():


### PR DESCRIPTION
<img width="1072" height="218" alt="image" src="https://github.com/user-attachments/assets/4a3f9aa9-78ec-4323-9826-86c56c11cb34" />


Fixes issue when a scan is being done by BBOT-Server and the asset doesn't exist yet.