### PR TITLE
Add optional Neo4j export for agent scans

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ Note: this requires Docker and Docker Compose to be installed.
 bbctl server start
 ```
 
+### Export scan output to Neo4j when running agents
+
+Agents can mirror scan events into a Neo4j database alongside the BBOT server output. Start the agent with `--neo4j-output` and configure the connection details under `agent.neo4j_output` in your BBOT server config (e.g. `~/.config/bbot_server/config.yml`).
+
+```bash
+bbctl agent start --id <AGENT_ID> --name <AGENT_NAME> --neo4j-output
+```
+
 ## Interacting with BBOT Server Remotely (Multiplayer)
 
 By default, BBOT Server listens on localhost. Use `--listen` to expose it to the network:

--- a/bbot_server/cli/bbctl.py
+++ b/bbot_server/cli/bbctl.py
@@ -8,6 +8,10 @@ from omegaconf import OmegaConf
 from rich.console import Console
 from functools import cached_property
 
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
 import bbot_server.config as bbcfg
 from bbot_server.cli.base import BaseBBCTL, Annotated, Option
 from bbot_server.errors import BBOTServerError, BBOTServerUnauthorizedError

--- a/bbot_server/defaults.yml
+++ b/bbot_server/defaults.yml
@@ -32,6 +32,11 @@ agent:
         - DNS_NAME_UNRESOLVED
         - RAW_TEXT
         - WEB_PARAMETER
+  # Default Neo4j connection details used when enabling --neo4j-output on agents
+  neo4j_output:
+    uri: bolt://localhost:7687
+    username: neo4j
+    password: bbotislife
 
 cli:
   http_timeout: 90

--- a/bbot_server/modules/agents/agent.py
+++ b/bbot_server/modules/agents/agent.py
@@ -12,6 +12,7 @@ import bbot_server.config as bbcfg
 from bbot.scanner import Scanner, Preset
 from bbot.scanner.dispatcher import Dispatcher
 from bbot.constants import get_scan_status_code, get_scan_status_name, SCAN_STATUS_NOT_STARTED, SCAN_STATUS_FAILED
+from omegaconf import OmegaConf
 
 from bbot_server.errors import BBOTServerValueError
 from bbot_server.utils.async_utils import async_to_sync_class
@@ -59,11 +60,12 @@ class BBOTAgent:
     - get full scan status (with detailed module status)
     """
 
-    def __init__(self, id: str, name: str, config):
+    def __init__(self, id: str, name: str, config, enable_neo4j_output: bool = False):
         self.log = logging.getLogger("bbot_server.agent")
         self.id = id
         self.name = name
         self.config = config
+        self.enable_neo4j_output = enable_neo4j_output
         self.server_url = config.url
         self.parsed_server_url = urlparse(self.server_url)
         self.websocket_scheme = "ws" if self.parsed_server_url.scheme == "http" else "wss"
@@ -215,14 +217,29 @@ class BBOTAgent:
         default_preset = Preset.from_dict(default_bbot_preset)
 
         # agent-specific overrides for output url etc.
-        agent_preset = Preset(
-            output_modules=["http"],
-            config={
-                "modules": {
-                    "http": {"url": self.scan_output_url, "headers": {bbcfg.API_KEY_NAME: bbcfg.get_api_key()}}
-                }
-            },
-        )
+        output_modules = ["http"]
+        module_config = {
+            "http": {"url": self.scan_output_url, "headers": {bbcfg.API_KEY_NAME: bbcfg.get_api_key()}}
+        }
+
+        if self.enable_neo4j_output:
+            self.log.info("Enabling Neo4j output for agent %s", self.name)
+            agent_config = self.config.get("agent", {}) or {}
+            try:
+                neo4j_output_config = OmegaConf.to_container(agent_config.get("neo4j_output", {}), resolve=True)
+            except Exception:
+                neo4j_output_config = agent_config.get("neo4j_output", {}) or {}
+
+            neo4j_options = {
+                "uri": neo4j_output_config.get("uri", "bolt://localhost:7687"),
+                "username": neo4j_output_config.get("username", "neo4j"),
+                "password": neo4j_output_config.get("password", "bbotislife"),
+            }
+
+            output_modules.append("neo4j")
+            module_config["neo4j"] = neo4j_options
+
+        agent_preset = Preset(output_modules=output_modules, config={"modules": module_config})
 
         default_preset.merge(agent_preset)
         return default_preset

--- a/bbot_server/modules/agents/agents_cli.py
+++ b/bbot_server/modules/agents/agents_cli.py
@@ -64,12 +64,25 @@ class AgentCTL(BaseBBCTL):
         self,
         agent_id: Annotated[str, Option("--id", "-i", help="ID of the agent to start", metavar="UUID")],
         agent_name: Annotated[str, Option("--name", "-n", help="Name of the agent", metavar="STRING")],
+        neo4j_output: Annotated[
+            bool,
+            Option(
+                "--neo4j-output",
+                help="Also export scan output to Neo4j using connection details from the config",
+            ),
+        ] = False,
     ):
         print("Starting BBOT agent")
 
         from bbot_server.modules.agents.agent import BBOTAgent
 
-        agent = BBOTAgent(agent_id, agent_name, self.root.config, synchronous=True)
+        agent = BBOTAgent(
+            agent_id,
+            agent_name,
+            self.root.config,
+            enable_neo4j_output=neo4j_output,
+            synchronous=True,
+        )
         try:
             self.log.info("Starting agent")
             agent.loop()

--- a/tests/test_cli/test_cli_basic.py
+++ b/tests/test_cli/test_cli_basic.py
@@ -51,3 +51,9 @@ event_store:
     config = yaml.safe_load(result.stdout)
     assert config["event_store"]["uri"] == "mongodb://localhost:27017/asdf"
     temp_config_path.unlink()
+
+
+def test_agent_start_help_includes_neo4j_option():
+    result = subprocess.run(BBCTL_COMMAND + ["agent", "start", "--help"], capture_output=True, text=True)
+    assert result.returncode == 0
+    assert "--neo4j-output" in result.stdout


### PR DESCRIPTION
- add a ``--neo4j-output`` flag to the agent start command and document how to enable Neo4j exports
- wire agent presets to include the Neo4j output module when the flag is set and provide default connection settings
- make the bbctl entrypoint runnable directly from the source tree without installation