### PR TITLE
Improve version publishing

### DIFF
--- a/.github/workflows/docker-tests.yml
+++ b/.github/workflows/docker-tests.yml
@@ -96,9 +96,9 @@ jobs:
           type=ref,event=branch
           type=sha,prefix=sha-
           type=raw,value=latest,enable=${{ github.ref == 'refs/heads/stable' }}
-          type=raw,value=v${{ steps.version.outputs.major }},enable=${{ github.ref == 'refs/heads/stable' }}
-          type=raw,value=v${{ steps.version.outputs.minor }},enable=${{ github.ref == 'refs/heads/stable' }}
-          type=raw,value=v${{ steps.version.outputs.version }},enable=${{ github.ref == 'refs/heads/stable' }}
+          type=raw,value=${{ steps.version.outputs.major }},enable=${{ github.ref == 'refs/heads/stable' }}
+          type=raw,value=${{ steps.version.outputs.minor }},enable=${{ github.ref == 'refs/heads/stable' }}
+          type=raw,value=${{ steps.version.outputs.version }},enable=${{ github.ref == 'refs/heads/stable' }}
 
     - name: Build and push Docker image
       uses: docker/build-push-action@v6
@@ -118,7 +118,7 @@ jobs:
         echo "Cleaning up bbot-server tags..."
 
         # Protected tags that should never be deleted
-        PROTECTED="latest stable dev v${{ steps.version.outputs.major }} v${{ steps.version.outputs.minor }} v${{ steps.version.outputs.version }}"
+        PROTECTED="latest stable dev ${{ steps.version.outputs.major }} ${{ steps.version.outputs.minor }} ${{ steps.version.outputs.version }}"
 
         tags_response=$(curl -s -H "Authorization: Bearer ${{ secrets.DOCKER_TOKEN }}" \
           "https://hub.docker.com/v2/repositories/blacklanternsecurity/bbot-server/tags/?page_size=100")
@@ -166,18 +166,15 @@ jobs:
       run: |
         VERSION="${{ steps.version.outputs.version }}"
         CHART_VERSION="$VERSION"
-        IMAGE_TAG="stable"
         if [ "${{ github.ref }}" = "refs/heads/dev" ]; then
           CHART_VERSION="${VERSION}-dev"
-          IMAGE_TAG="dev"
         fi
         sed -i "s/^version:.*/version: ${CHART_VERSION}/" helm/Chart.yaml
         sed -i "s/^appVersion:.*/appVersion: \"${VERSION}\"/" helm/Chart.yaml
-        # ensure the packaged chart defaults to the correct docker image tag
-        sed -i "s/^  tag:.*/  tag: \"${IMAGE_TAG}\"/" helm/values.yaml
+        # image.tag defaults to .Chart.AppVersion in the templates,
+        # so no need to sed values.yaml — the version flows automatically.
         echo "Chart version: $CHART_VERSION"
         echo "App version: $VERSION"
-        echo "Image tag: $IMAGE_TAG"
         cat helm/Chart.yaml
 
     - name: Add Helm repositories

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,6 +86,6 @@ jobs:
           git config --local user.name "GitHub Actions"
       - name: Tag commit
         run: |
-          VERSION="v${{ needs.publish_pypi.outputs.VERSION }}"
+          VERSION="${{ needs.publish_pypi.outputs.VERSION }}"
           git tag -a "$VERSION" -m "Stable Release $VERSION"
           git push origin "$VERSION"

--- a/helm/templates/server-deployment.yaml
+++ b/helm/templates/server-deployment.yaml
@@ -28,7 +28,7 @@ spec:
       - name: server
         securityContext:
           allowPrivilegeEscalation: false
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command: ["bbctl", "server", "start", "--api-only", "--listen", "0.0.0.0"]
         ports:

--- a/helm/templates/worker-deployment.yaml
+++ b/helm/templates/worker-deployment.yaml
@@ -27,7 +27,7 @@ spec:
       # Wait for the API server to become healthy before starting the worker
       initContainers:
       - name: wait-for-server
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         securityContext:
           allowPrivilegeEscalation: false
@@ -45,7 +45,7 @@ spec:
       - name: worker
         securityContext:
           allowPrivilegeEscalation: false
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command: ["bbctl", "server", "start", "--worker-only"]
         env:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -3,9 +3,9 @@
 # =============================================================================
 
 # -- Docker image configuration
+# image.tag defaults to .Chart.AppVersion (e.g. "0.1.5") if not overridden.
 image:
   repository: blacklanternsecurity/bbot-server
-  tag: "stable"
   pullPolicy: IfNotPresent
 
 # -- Image pull secrets for private registries

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bbot-server"
-version = "0.1.4"
+version = "0.1.5"
 description = ""
 authors = [{name = "TheTechromancer"}]
 license = "AGPL-3.0"


### PR DESCRIPTION
## Summary
- Bump bbot-server from 0.1.4 to 0.1.5
- bbot-server subchart now defaults `image.tag` to `.Chart.AppVersion` instead of hardcoding `"stable"` — so bumping the subchart dependency version in `helm/Chart.yaml` automatically pulls the matching Docker image with no manual override needed
- Drop `v` prefix from Docker image tags and git tags (e.g. `0.1.5` instead of `v0.1.5`)
- Add version coupling documentation in `helm/values.yaml` explaining the relationship between the helm subchart and the backend's Python dependency, and what to update when bumping

## Context
The enterprise backend and the bbot-server worker both run bbot-server code but from different Docker images. Previously, the subchart hardcoded `image.tag: "stable"`, a floating tag that could drift from the pinned chart version. Now the image tag is derived from `appVersion`, which CI sets from `pyproject.toml` — making `pyproject.toml` the single source of version truth for Python, Docker, and Helm.

Once bbot 3.0 lands on PyPI, bbot-server will publish there too, and the backend can pin to a PyPI release instead of a git branch, eliminating the remaining manual version alignment.