### PR TITLE
Toggle Reconciling Indexes

### DIFF
--- a/bbot_server/applets/_root.py
+++ b/bbot_server/applets/_root.py
@@ -45,7 +45,7 @@ class RootApplet(BaseApplet):
         await self._setup()
 
         # Reconcile indexes after all applets are set up
-        if self.is_native:
+        if self.is_native and bbcfg.reconcile_indexes:
             await self.reconcile_all_indexes()
 
         return True, ""

--- a/bbot_server/config.py
+++ b/bbot_server/config.py
@@ -84,6 +84,9 @@ class BBOTServerSettings(BaseSettings):
     user_store: StoreConfig
     message_queue: MessageQueueConfig
 
+    # index management
+    reconcile_indexes: bool = True
+
     # misc nested config we know about
     agent: Optional[AgentConfig] = Field(default_factory=AgentConfig)
     cli: Optional[CLIConfig] = Field(default_factory=CLIConfig)

--- a/compose.yml
+++ b/compose.yml
@@ -28,6 +28,8 @@ services:
   worker:
     <<: *bbot-server-base
     command: ["bbctl", "server", "start", "--worker-only"]
+    environment:
+      - BBOT_SERVER_RECONCILE_INDEXES=false
     depends_on:
       server:
         condition: service_healthy

--- a/helm/templates/worker-deployment.yaml
+++ b/helm/templates/worker-deployment.yaml
@@ -62,6 +62,9 @@ spec:
             secretKeyRef:
               name: {{ .Values.redis.auth.existingSecret | default (printf "%s-redis" .Release.Name) | quote }}
               key: redis-password
+        # Index reconciliation is handled by Server, not the worker
+        - name: BBOT_SERVER_RECONCILE_INDEXES
+          value: "false"
         # BBOT Server configuration
         - name: BBOT_SERVER_URL
           value: "http://{{ .Release.Name }}-server:{{ .Values.server.service.port }}/v1/"


### PR DESCRIPTION
Implement toggling off/on of reconciling MongoDB indexes. Prevents the worker from messing with the MongoDB indexes when it should be BBOT Server handling those.