### PR TITLE
Move `last_seen` from Technology to Asset model.

### DIFF
--- a/bbot_server/models/base.py
+++ b/bbot_server/models/base.py
@@ -101,6 +101,7 @@ class BaseAssetFacet(BaseHostModel):
 
     # scope is an array of target IDs, which are dynamically maintained as new scan data arrives, or as targets are created/updated.
     scope: Annotated[list[UUID], "indexed"] = []
+    last_seen: Annotated[Optional[float], "indexed"] = None
 
     # unless overridden, all asset facets are stored in the asset store
     __store_type__ = "asset"

--- a/bbot_server/modules/technologies/technologies_models.py
+++ b/bbot_server/modules/technologies/technologies_models.py
@@ -1,7 +1,6 @@
 from pydantic import Field, computed_field
 from typing import Annotated
 
-from bbot_server.utils.misc import utc_now
 from bbot_server.models.base import AssetQuery, BaseAssetFacet
 
 
@@ -20,7 +19,6 @@ class TechnologyQuery(AssetQuery):
 
 class Technology(BaseAssetFacet):
     technology: Annotated[str, "indexed", "indexed-text"]
-    last_seen: Annotated[float, "indexed"] = Field(default_factory=utc_now)
 
     @computed_field
     @property

--- a/tests/test_asset_indexes.py
+++ b/tests/test_asset_indexes.py
@@ -69,6 +69,7 @@ async def test_asset_indexes():
     assert bbot_server.assets.model.indexed_fields() == {
         "host": ["indexed"],
         "scope": ["indexed"],
+        "last_seen": ["indexed"],
         "created": ["indexed"],
         "modified": ["indexed"],
         "dns_links": ["indexed"],


### PR DESCRIPTION
This makes it easier to subclass Asset and `last_seen` is a more important field. 
Note: We already pass `last_seen=event.timestamp` explicitly everywhere, this will just affect the fallback. 