### PR TITLE
Publish helm chart to separate repo

### DIFF
--- a/.github/workflows/docker-tests.yml
+++ b/.github/workflows/docker-tests.yml
@@ -190,4 +190,4 @@ jobs:
       run: echo "${{ secrets.DOCKER_TOKEN }}" | helm registry login registry-1.docker.io -u blacklanternsecurity --password-stdin
 
     - name: Push Helm chart to Docker Hub
-      run: helm push bbot-server-*.tgz oci://registry-1.docker.io/blacklanternsecurity
+      run: helm push bbot-server-helm-*.tgz oci://registry-1.docker.io/blacklanternsecurity

--- a/README.md
+++ b/README.md
@@ -75,13 +75,13 @@ BBOT Server can be deployed to Kubernetes using its official Helm chart. The cha
 helm repo add blacklanternsecurity https://blacklanternsecurity.github.io/bbot-server
 
 # Install
-helm install bbot blacklanternsecurity/bbot-server
+helm install bbot blacklanternsecurity/bbot-server-helm
 ```
 
 Or install directly from the OCI registry:
 
 ```bash
-helm install bbot oci://registry-1.docker.io/blacklanternsecurity/bbot-server
+helm install bbot oci://registry-1.docker.io/blacklanternsecurity/bbot-server-helm
 ```
 
 ### Configuration
@@ -89,7 +89,7 @@ helm install bbot oci://registry-1.docker.io/blacklanternsecurity/bbot-server
 Key values can be overridden with `--set` or a custom values file:
 
 ```bash
-helm install bbot blacklanternsecurity/bbot-server \
+helm install bbot blacklanternsecurity/bbot-server-helm \
   --set ingress.enabled=true \
   --set ingress.hosts[0].host=bbot.example.com \
   --set ingress.hosts[0].paths[0].path=/ \
@@ -121,7 +121,7 @@ secrets:
 ```
 
 ```bash
-helm install bbot blacklanternsecurity/bbot-server -f custom-values.yaml
+helm install bbot blacklanternsecurity/bbot-server-helm -f custom-values.yaml
 ```
 
 ### Retrieving the API Key
@@ -136,7 +136,7 @@ kubectl get secret bbot-api-key -o jsonpath='{.data.api-key}' | base64 -d
 
 ```bash
 helm repo update
-helm upgrade bbot blacklanternsecurity/bbot-server
+helm upgrade bbot blacklanternsecurity/bbot-server-helm
 ```
 
 ## Interacting with BBOT Server Remotely (Multiplayer)

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: bbot-server
+name: bbot-server-helm
 description: Helm chart for BBOT Server (API + Worker)
 type: application
 version: 0.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bbot-server"
-version = "0.2.0"
+version = "0.3.0"
 description = ""
 authors = [{name = "TheTechromancer"}]
 license = "AGPL-3.0"

--- a/uv.lock
+++ b/uv.lock
@@ -194,7 +194,7 @@ dependencies = [
 
 [[package]]
 name = "bbot-server"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "bbot" },


### PR DESCRIPTION
## Summary

Move the helm chart to its own Docker Hub repo (`blacklanternsecurity/bbot-server-helm`) to stop the docker image push from clobbering the helm chart manifest at shared bare-semver tags.

## Why

The `helm-publish` and `docker-publish` jobs both push to `blacklanternsecurity/bbot-server`. After `0e05b6a` dropped the `v`-prefix from docker tags, the docker push overwrote the helm chart at e.g. `0.1.5` and `0.1.6`, so `helm pull ... --version 0.1.6` now fails with:

> could not load config with mediatype application/vnd.cncf.helm.config.v1+json

Helm derives the OCI repo path from the chart's `name:`, so renaming the chart to `bbot-server-helm` routes future pushes to a separate repo. No more shared namespace, no more `v`-prefix dance.

## Changes

- `helm/Chart.yaml`: `name: bbot-server` → `name: bbot-server-helm`
- `.github/workflows/docker-tests.yml`: `helm push bbot-server-*.tgz` → `bbot-server-helm-*.tgz` (matches new packaged filename)
- `README.md`: update `helm install`/`upgrade` commands to use the new chart name
- Docker image repo, PyPI package, GitHub repo, `bbctl` CLI, and `app: bbot-server` k8s labels are **unchanged**

## Post-deploy verification

Run after `0.3.0` publishes on `stable`:

```bash
helm pull oci://registry-1.docker.io/blacklanternsecurity/bbot-server-helm --version 0.3.0
docker pull blacklanternsecurity/bbot-server:0.3.0
curl -s "https://hub.docker.com/v2/repositories/blacklanternsecurity/bbot-server/tags/?page_size=10" \
  | jq -r '.results[] | "\(.name)\t\(.media_type)"'
# every tag on the old repo should be application/vnd.oci.image.index.v1+json — no helm mediatypes
```
