### PR TITLE
refactor(applets): drop omegaconf for a dotted config lookup

### DIFF
--- a/bbot_server/applets/base.py
+++ b/bbot_server/applets/base.py
@@ -5,7 +5,6 @@ import logging
 import traceback
 
 from fastapi import APIRouter
-from omegaconf import OmegaConf
 from typing import Annotated, Any, get_origin, get_args, Union, Callable, cast  # noqa
 from functools import cached_property
 from pydantic import BaseModel, Field  # noqa
@@ -309,7 +308,7 @@ class BaseApplet:
                     raise ValueError(
                         f"{self.name}.{method_name}: When specifying a crontab config value, you must also give a default crontab value (kwarg: 'cron')"
                     )
-                cron = OmegaConf.select(self.global_config, cron_config_key, default=cron_default)
+                cron = bbot_server_misc.select_dotted(self.global_config, cron_config_key, default=cron_default)
                 kwargs["schedule"] = [{"cron": cron}]
             elif cron_default is not None:
                 kwargs["schedule"] = [{"cron": cron_default}]

--- a/bbot_server/utils/misc.py
+++ b/bbot_server/utils/misc.py
@@ -5,6 +5,7 @@ from bson import ObjectId
 from functools import wraps
 from types import UnionType
 from inspect import signature
+from collections.abc import Mapping
 from pydantic import BaseModel, create_model
 from datetime import datetime, timezone, timedelta
 from typing import Any, Union, get_origin, get_args, get_type_hints, Annotated
@@ -150,6 +151,31 @@ def human_friendly_kwargs(fn):
         return wrapper
 
     return fn
+
+
+def select_dotted(obj: Any, key: str, default: Any = None) -> Any:
+    """
+    Resolve a dotted config key against a pydantic model or mapping.
+
+    Args:
+        obj: Root config object to traverse
+        key: Dotted path, e.g. "modules.foo.cron"
+        default: Returned if any segment is missing or resolves to None
+
+    Returns:
+        The resolved value, or default.
+    """
+    current = obj
+    for segment in key.split("."):
+        if isinstance(current, Mapping):
+            if segment not in current:
+                return default
+            current = current[segment]
+        else:
+            if not hasattr(current, segment):
+                return default
+            current = getattr(current, segment)
+    return default if current is None else current
 
 
 def utc_now() -> float:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ dependencies = [
     "pymongo>=4.15.3",
     "cloudcheck>=9.2.0",
     "textual>=7.5.0",
-    "omegaconf>=2.3.0,<3",
     "bbot",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -98,12 +98,6 @@ wheels = [
 ]
 
 [[package]]
-name = "antlr4-python3-runtime"
-version = "4.9.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3e/38/7859ff46355f76f8d19459005ca000b6e7012f2f1ca597746cbcd1fbfe5e/antlr4-python3-runtime-4.9.3.tar.gz", hash = "sha256:f224469b4168294902bb1efa80a8bf7855f24c99aef99cbefc1bcd3cce77881b", size = 117034, upload-time = "2021-11-06T17:52:23.524Z" }
-
-[[package]]
 name = "anyio"
 version = "4.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -210,7 +204,6 @@ dependencies = [
     { name = "jmespath" },
     { name = "jsondiff" },
     { name = "mcp" },
-    { name = "omegaconf" },
     { name = "orjson" },
     { name = "pymongo" },
     { name = "redis" },
@@ -244,7 +237,6 @@ requires-dist = [
     { name = "jmespath", specifier = ">=1.0.1" },
     { name = "jsondiff", specifier = ">=2.2.1" },
     { name = "mcp", specifier = "==1.7.0" },
-    { name = "omegaconf", specifier = ">=2.3.0,<3" },
     { name = "orjson", specifier = ">=3.10.12" },
     { name = "pymongo", specifier = ">=4.15.3" },
     { name = "redis", specifier = ">=5.2.1" },
@@ -1505,19 +1497,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/21/54/1d71cd143752361c0aebef16ad3f55926a6faf7b112d355745c1f8a25f7f/mmh3-5.2.1-cp314-cp314t-win32.whl", hash = "sha256:29bc3973676ae334412efdd367fcd11d036b7be3efc1ce2407ef8676dabfeb82", size = 41934, upload-time = "2026-03-05T15:55:53.564Z" },
     { url = "https://files.pythonhosted.org/packages/9d/e4/63a2a88f31d93dea03947cccc2a076946857e799ea4f7acdecbf43b324aa/mmh3-5.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:28cfab66577000b9505a0d068c731aee7ca85cd26d4d63881fab17857e0fe1fb", size = 43036, upload-time = "2026-03-05T15:55:55.252Z" },
     { url = "https://files.pythonhosted.org/packages/a0/0f/59204bf136d1201f8d7884cfbaf7498c5b4674e87a4c693f9bde63741ce1/mmh3-5.2.1-cp314-cp314t-win_arm64.whl", hash = "sha256:dfd51b4c56b673dfbc43d7d27ef857dd91124801e2806c69bb45585ce0fa019b", size = 40391, upload-time = "2026-03-05T15:55:56.697Z" },
-]
-
-[[package]]
-name = "omegaconf"
-version = "2.3.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "antlr4-python3-runtime" },
-    { name = "pyyaml" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ce/3d/e4b57b8d9008c6ebe0d5eff901f91d5700cf7bdb8c8863df817463a7fd5e/omegaconf-2.3.1.tar.gz", hash = "sha256:e5e7de64aeebeddaf8e6d3f7a783b32ac2a01c0fbd9c878012caecb891a1f42a", size = 3298472, upload-time = "2026-06-11T05:05:12.885Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/0e/152509871bf30df6fc38569f52a2db9b55dd41aae957adae50a053ac7778/omegaconf-2.3.1-py3-none-any.whl", hash = "sha256:3d701d14e9a8828f1edd28bb70b725908b34277cdd72cf7d6a83f94dadc6b6a0", size = 79502, upload-time = "2026-06-11T05:05:09.954Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
`applets/base.py` imported `OmegaConf` for exactly one call site, which ran `OmegaConf.select` against `self.global_config`. That object is a pydantic `BBOTServerSettings`, not a `DictConfig`, so it was the wrong API for the type.

Replace it with `select_dotted` in `utils/misc.py`, which walks the dotted path over pydantic models and mappings alike and returns the default when a segment is missing or resolves to None.

Drops omegaconf and antlr4-python3-runtime from the lock.

Based on `pin-bbot-v3.0.2` (#165) since that branch declares the omegaconf dependency this removes. Retarget to `stable` once #165 lands.

Verified: `ruff check` passes, `ruff format --diff` clean, `uv sync --frozen` exits 0, and `select_dotted` resolves nested pydantic paths, dict paths, missing segments, and None values to the default.

Closes #166